### PR TITLE
Update to support opa 0.15.0 Wasm API's

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ Example:
 
 ```javascript
 
-input = '{"path": "/", "role": "admin"}'
+input = '{"path": "/", "role": "admin"}';
 
 rego.load_policy(policy_wasm).then(policy => {
-    allowed = policy.eval_bool(input)
-    console.log("allowed = " + allowed)
-}, error => {
-    console.error("Failed to load policy: " + error)
+    allowed = policy.eval_bool(input);
+    console.log("allowed = " + allowed);
+}).catch( error => {
+    console.error("Failed to load policy: " + error);
 })
 ```
 

--- a/examples/nodejs-app/README.md
+++ b/examples/nodejs-app/README.md
@@ -16,19 +16,15 @@ npm install
 There is an example policy included with the example, see [example.rego](./example.rego)
 
 ```bash
-opa build -d example.rego 'data.example.allow = true'
+opa build -d example.rego 'data.example'
 ```
 
 ## Run the example Node JS code that invokes the Wasm binary:
 
 ```bash
-node app.js '{"method": "get", "path": "/trades"}'
+node app.js '{"message": "world"}'
 ```
 
 ```bash
-node app.js '{"method": "post", "path": "/trades"}'
-```
-
-```bash
-node app.js '{"method": "post", "path": "/trades", "role": "admin"}'
+node app.js '{"message": "not-world"}'
 ```

--- a/examples/nodejs-app/app.js
+++ b/examples/nodejs-app/app.js
@@ -3,28 +3,29 @@
 // license that can be found in the LICENSE file.
 
 const fs = require('fs');
-const Rego = require("@open-policy-agent/opa-wasm")
+const Rego = require("@open-policy-agent/opa-wasm");
 
 // Read the policy wasm file
-const policy_wasm = fs.readFileSync('policy.wasm')
+const policy_wasm = fs.readFileSync('policy.wasm');
 
 // Initialize the Rego object and load the wasm program
-const rego = new Rego()
+const rego = new Rego();
+
+// Load the policy module asynchronously
 rego.load_policy(policy_wasm).then(policy => {
 
     // Use console parameters for the input, do quick
     // validation by json parsing. Not efficient.. but
     // will raise an error 
-    const input = JSON.stringify(JSON.parse(process.argv[2]))
+    const input = JSON.stringify(JSON.parse(process.argv[2]));
 
-    const allow = policy.eval_bool(input)
+    // Provide a data document with a string value
+    policy.set_data({world: "world"});
 
-    if (allow) {
-        console.log("Decision: ALLOW");
-    } else {
-        console.log("Decision: DENY");
-    }
+    // Evaluate the policy and log the result
+    const result = policy.evaluate(input);
+    console.log(JSON.stringify(result, null, 2))
 
-}, error => {
-    console.log("ERROR: " + error)
-})
+}).catch(err => {
+    console.log("ERROR: " + err)
+});

--- a/examples/nodejs-app/example.rego
+++ b/examples/nodejs-app/example.rego
@@ -1,12 +1,8 @@
 package example
 
-allow {
-    input.method = "get"
-    input.path = "/trades"
-}
+default hello = false
 
-allow {
-    input.method = "post"
-    input.path = "/trades"
-    input.role = "admin"
+hello {
+    x := input.message
+    x == data.world
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@open-policy-agent/opa-wasm",
-  "version": "0.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-policy-agent/opa-wasm",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Open Policy Agent WebAssembly SDK",
   "main": "src/opa.js",
   "scripts": {},

--- a/src/opa.js
+++ b/src/opa.js
@@ -5,13 +5,48 @@
 function stringDecoder(mem) {
     return function(addr) {
         const i8 = new Int8Array(mem.buffer);
-        const start = addr;
-        var s = "";
-        while (i8[addr] != 0) {
+        let s = "";
+        while (i8[addr] !== 0) {
             s += String.fromCharCode(i8[addr++]);
         }
         return s;
     }
+}
+
+function _loadJSON(wasmInstance, memory, value) {
+    if (value === undefined) {
+        throw "unable to load undefined value into memory"
+    }
+
+    const str = JSON.stringify(value);
+    const rawAddr = wasmInstance.exports.opa_malloc(str.length);
+    const buf = new Uint8Array(memory.buffer);
+
+    for (let i = 0; i < str.length; i++) {
+        buf[rawAddr + i] = str.charCodeAt(i);
+    }
+
+    const parsedAddr = wasmInstance.exports.opa_json_parse(rawAddr, str.length);
+
+    if (parsedAddr === 0) {
+        throw "failed to parse json value"
+    }
+
+    return parsedAddr;
+}
+
+function _dumpJSON(wasmInstance, memory, addr) {
+    const rawAddr = wasmInstance.exports.opa_json_dump(addr);
+    const buf = new Uint8Array(memory.buffer);
+
+    let s = '';
+    let idx = rawAddr;
+
+    while (buf[idx] !== 0) {
+        s += String.fromCharCode(buf[idx++]);
+    }
+
+    return JSON.parse(s);
 }
 
 // _load_policy can take in either an ArrayBuffer or WebAssembly.Module
@@ -19,13 +54,16 @@ function stringDecoder(mem) {
 // It will return a Promise, depending on the input type the promise
 // resolves to both a compiled WebAssembly.Module and its first WebAssembly.Instance
 // or to the WebAssemblyInstance.
-async function _load_policy(policy_wasm, memory, ) {
+async function _load_policy(policy_wasm, memory) {
     const addr2string = stringDecoder(memory);
     return await WebAssembly.instantiate(policy_wasm, {
         env: {
             memory: memory,
             opa_abort: function(addr) {
                 throw addr2string(addr);
+            },
+            opa_println: function (addr) {
+                console.log(addr2string(addr));
             },
         },
     });
@@ -36,27 +74,59 @@ async function _load_policy(policy_wasm, memory, ) {
 // handle the output from the policy wasm.
 class LoadedPolicy {
     constructor(policy, memory) {
-        this.mem = memory
+        this.mem = memory;
 
         // Depending on how the wasm was instantiated "policy" might be a
         // WebAssembly Instance or be a wrapper around the Module and
         // Instance. We only care about the Instance.
-        this.policy = policy.instance ? policy.instance : policy
+        this.wasmInstance = policy.instance ? policy.instance : policy;
+
+        this.dataAddr = _loadJSON(this.wasmInstance, this.mem, {});
+        this.baseHeapPtr = this.wasmInstance.exports.opa_heap_ptr_get();
+        this.baseHeapTop = this.wasmInstance.exports.opa_heap_top_get();
+        this.dataHeapPtr = this.baseHeapPtr;
+        this.dataHeapTop = this.baseHeapTop;
+    }
+
+    // evaluate will evaluate the loaded policy with the given input and
+    // return the result set. This should be re-used for multiple evaluations
+    // of the same policy with different inputs.
+    evaluate(input) {
+        // Reset the heap pointer before each evaluation
+        this.wasmInstance.exports.opa_heap_ptr_set(this.dataHeapPtr);
+        this.wasmInstance.exports.opa_heap_top_set(this.dataHeapTop);
+
+        // Load the input data
+        const inputAddr = _loadJSON(this.wasmInstance, this.mem, input);
+
+        // Setup the evaluation context
+        const ctxAddr = this.wasmInstance.exports.opa_eval_ctx_new();
+        this.wasmInstance.exports.opa_eval_ctx_set_input(ctxAddr, inputAddr);
+        this.wasmInstance.exports.opa_eval_ctx_set_data(ctxAddr, this.dataAddr);
+
+        // Actually evaluate the policy
+        this.wasmInstance.exports.eval(ctxAddr);
+
+        // Retrieve the result
+        const resultAddr = this.wasmInstance.exports.opa_eval_ctx_get_result(ctxAddr);
+        return _dumpJSON(this.wasmInstance, this.mem, resultAddr)
     }
 
     // eval_bool will evaluate the policy and return a boolean answer
     // depending on the return code from the policy evaluation.
+    // Deprecated: Use `evaluate` instead.
     eval_bool(input) {
-        const addr = this.policy.exports.opa_malloc(input.length);
-        const buf = new Uint8Array(this.mem.buffer);
+        const rs = this.evaluate(input);
+        return (rs && rs.length === 1 && rs[0] === true)
+    }
 
-        for(let i = 0; i < input.length; i++) {
-            buf[addr+i] = input.charCodeAt(i);
-        }
-
-        const returnCode = this.policy.exports.eval(addr, input.length);
-
-        return Boolean(returnCode);
+    // set_data will load data for use in subsequent evaluations.
+    set_data(data) {
+        this.wasmInstance.exports.opa_heap_ptr_set(this.baseHeapPtr);
+        this.wasmInstance.exports.opa_heap_top_set(this.baseHeapTop);
+        this.dataAddr = _loadJSON(this.wasmInstance, this.mem, data);
+        this.dataHeapPtr = this.wasmInstance.exports.opa_heap_ptr_get();
+        this.dataHeapTop = this.wasmInstance.exports.opa_heap_top_get();
     }
 }
 
@@ -67,7 +137,7 @@ module.exports = class Rego {
     // the policy.
     async load_policy(wasm) {
         const memory = new WebAssembly.Memory({initial: 5});
-        const policy = await _load_policy(wasm, memory)
+        const policy = await _load_policy(wasm, memory);
         return new LoadedPolicy(policy, memory)
     }
 };


### PR DESCRIPTION
This updates the example to use the newer API's and evaluation
workflow.