### PR TITLE
ci: simplify e2e.sh, bump opa version (0.23.2 -> 0.26.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install Open Policy Agent CLI
       run: >
         mkdir -p ${{ runner.tool_cache }}/opa &&
-        curl -sSL https://openpolicyagent.org/downloads/v0.23.2/opa_linux_amd64 -o ${{ runner.tool_cache }}/opa/opa &&
+        curl -sSL https://openpolicyagent.org/downloads/v0.26.0/opa_linux_amd64 -o ${{ runner.tool_cache }}/opa/opa &&
         chmod +x ${{ runner.tool_cache }}/opa/opa &&
         echo "${{ runner.tool_cache }}/opa" >> $GITHUB_PATH
     - run: npm ci

--- a/e2e.sh
+++ b/e2e.sh
@@ -13,7 +13,7 @@ npm run build
 
 echo "Running tests..."
 echo -n "When input.message == world, return hello == true "
-if npm start --silent -- '{ "mexssage": "world" }' | jq -e '.[0].result' >/dev/null; then
+if npm start --silent -- '{ "message": "world" }' | jq -e '.[0].result' >/dev/null; then
   echo "✔"
 else
   echo "✖"

--- a/e2e.sh
+++ b/e2e.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-set -ueE
-trap 'EXIT_CODE=$?; echo "ERR at line ${LINENO} (exit code: $EXIT_CODE)"; exit $EXIT_CODE' ERR
+set -e
 
 npm run types
 
@@ -13,8 +12,20 @@ echo "Building wasm bundle..."
 npm run build
 
 echo "Running tests..."
-RESULT="$(npm start --silent -- '{ "message": "world" }' | jq '.[0].result')"
-echo "When input.message == world, return hello == true $(if [ $RESULT = "true" ]; then echo "✔" ; else echo "✖"; fi)"
+echo -n "When input.message == world, return hello == true "
+if npm start --silent -- '{ "mexssage": "world" }' | jq -e '.[0].result' >/dev/null; then
+  echo "✔"
+else
+  echo "✖"
+  fail=1
+  fi
 
-RESULT="$(npm start --silent -- '{ "message": "not-world" }' | jq '.[0].result')"
-echo "When input.message != world, return hello == false $(if [ $RESULT = "false" ]; then echo "✔" ; else echo "✖"; fi)"
+echo -n "When input.message != world, return hello == false "
+if npm start --silent -- '{ "message": "not-world" }' | jq -e '.[0].result | not' >/dev/null; then
+  echo "✔"
+else
+  echo "✖"
+  fail=1
+fi
+
+exit $fail


### PR DESCRIPTION
ℹ️ This change was prompted by using the script in OPA's CI, https://github.com/open-policy-agent/opa/pull/3094, and noticing that although I had forgotten to `npm install` before, the overall run wasn't a _fail_. 