### PR TITLE
github workflow: push to npm on tag-push

### DIFF
--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -1,7 +1,8 @@
 name: Publish Node.js Package
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+    - '*'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It seems what I had attempted with tying the repo push into
release creation didn't work the way I had expected. Let's go
with doing what we do for opa.
