### PR TITLE
run nodejs test cases from OPA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,20 +12,48 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x, 14.x]
+        opa-version: [0.26.0]
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Checkout OPA v${{ matrix.opa-version }}
+      uses: actions/checkout@v2
+      with:
+        repository: open-policy-agent/opa
+        ref: v${{ matrix.opa-version }}
+        path: opa
+
+    - run: mkdir test/cases
+
+    - name: Prep OPA cases
+      working-directory: opa
+      # TODO(sr): This make target runs the tests, too, and we don't need
+      # this here. However, to untangle PRs, let's done some extra work now
+      # and fix this situation later.
+      run: make wasm-rego-test
+
+    # NOTE(sr): we've got to get rid of the opa checkout because the test
+    # runner would otherwise pick up any .js files it finds in there.
+    - name: Unpack OPA cases
+    - run: >
+        tar zxvf opa/.go/cache/testcases.tar.gz --exclude='*.js' -C test/cases &&
+        rm -rf opa/
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Install Open Policy Agent CLI
+
+    - name: Install Open Policy Agent ${{ matrix.opa-version }}
       run: >
         mkdir -p ${{ runner.tool_cache }}/opa &&
-        curl -sSL https://openpolicyagent.org/downloads/v0.26.0/opa_linux_amd64 -o ${{ runner.tool_cache }}/opa/opa &&
+        curl -sSL https://openpolicyagent.org/downloads/v${{ matrix.opa-version }}/opa_linux_amd64 -o ${{ runner.tool_cache }}/opa/opa &&
         chmod +x ${{ runner.tool_cache }}/opa/opa &&
         echo "${{ runner.tool_cache }}/opa" >> $GITHUB_PATH
     - run: npm ci
     - run: npm run types
     - run: npm test
+      env:
+        OPA_CASES: test/cases/
     - run: ./e2e.sh

--- a/src/opa.js
+++ b/src/opa.js
@@ -27,7 +27,7 @@ function stringDecoder(mem) {
  */
 function _loadJSON(wasmInstance, memory, value) {
   if (value === undefined) {
-    throw "unable to load undefined value into memory";
+    return 0;
   }
 
   const str = utf8.encode(JSON.stringify(value));

--- a/src/opa.js
+++ b/src/opa.js
@@ -251,7 +251,7 @@ class LoadedPolicy {
   }
 
   /**
-   * eval_bool will evaluate the policy and return a boolean answer
+   * evalBool will evaluate the policy and return a boolean answer
    * depending on the return code from the policy evaluation.
    * @deprecated Use `evaluate` instead.
    * @param {object} input

--- a/test/opa-node-cases.test.js
+++ b/test/opa-node-cases.test.js
@@ -1,0 +1,78 @@
+const { loadPolicy } = require('../src/opa.js');
+const { readFileSync, readdirSync } = require('fs');
+
+let files = [];
+const path = process.env.OPA_CASES;
+if (path === undefined) {
+  describe('opa nodejs cases', () => {
+    test.todo('not found, set OPA_CASES env var');
+  });
+} else {
+  files = readdirSync(path);
+}
+let numFiles = 0;
+var testCases = [];
+
+files.forEach(file => {
+  if (file.endsWith('.json')) {
+    numFiles++;
+    const testFile = JSON.parse(readFileSync(path + "/" + file));
+    if (Array.isArray(testFile.cases)) {
+      testFile.cases.forEach(testCase => {
+        testCase.note = `${file}: ${testCase.note}`;
+        if (testCase.note === '018_builtins.json: custom built-in' ||
+            testCase.note === '018_builtins.json: impure built-in' ||
+            testCase.note === '019_call_indirect_optimization.json: memoization') {
+          testCase.skip = 'skipping tests with custom builtins';
+        }
+        testCases.push(testCase);
+      });
+    }
+  }
+});
+
+testCases.forEach(tc => {
+  const {
+    wasm,
+    input,
+    data,
+    note,
+    want_defined,
+    want_result,
+    want_error,
+    skip_reason,
+    skip
+  } = tc;
+  describe(note, () => {
+    if (skip) {
+      test.skip(`skip ${note}: ${skip_reason}`, () => {});
+      return;
+    }
+
+    if (want_error) {
+      if('errors', async() => {
+        const policy = await loadPolicy(Buffer.from(wasm, 'base64'));
+        policy.setData(data);
+        expect(() => policy.evaluate(input)).toThrow(want_error);
+      });
+      return;
+    }
+
+    it('has the desired result', async () => {
+      const policy = await loadPolicy(Buffer.from(wasm, 'base64'));
+      policy.setData(data || {});
+      const result = policy.evaluate(input);
+      if (want_defined !== undefined) {
+        if (want_defined) {
+          expect(result.length).toBeGreaterThan(0);
+        } else {
+          expect(result.length).toBe(0);
+        }
+      }
+      if (want_result !== undefined) {
+        expect(result.length).toEqual(want_result.length);
+        expect(result).toEqual(expect.arrayContaining(want_result));
+      }
+    });
+  });
+});


### PR DESCRIPTION
These tests only exercise what the wasm module supports natively; but running them with the SDK has helped me to pin down two things around input and data being undefined, so let's include this.

There's a TODO in the github workflow, we can drop some superfluous work done here when refactoring OPA's make targets a little. But right now, it works, and the extra work done *here* isn't going to be too annoying, I hope.