### PR TITLE
fix: wasm memory size limit

### DIFF
--- a/src/opa.js
+++ b/src/opa.js
@@ -298,10 +298,15 @@ module.exports = {
    * Takes in either an ArrayBuffer or WebAssembly.Module
    * and will return a LoadedPolicy object which can be used to evaluate
    * the policy.
+   *
+   * To set custom memory size specify number of memory pages 
+   * as second param.
+   * Defaults to 5 pages (320KB).
    * @param {BufferSource | WebAssembly.Module} regoWasm
+   * @param {number} memorySize
    */
-  async loadPolicy(regoWasm) {
-    const memory = new WebAssembly.Memory({ initial: 5 });
+  async loadPolicy(regoWasm, memorySize = 5) {
+    const memory = new WebAssembly.Memory({ initial: memorySize });
     const policy = await _loadPolicy(regoWasm, memory);
     return new LoadedPolicy(policy, memory);
   }


### PR DESCRIPTION
Make the wasm memory buffer size configurable.
This fixes an `data segment is out of bounds` error
when the data segment requires more than 5 pages of memory

The default value is kept to 5 pages which should make no impact on existing users

# How to replicate

You can run following command from https://github.com/p0tr3c/opa-wasm-bug-reproducer to reproduce
```
make test_wasm_bundle file_count=150
policyDir: /tmp/wasm_validation-ynmTR8GU
ERROR:  [RuntimeError: WebAssembly.instantiate(): data segment is out of bounds
```