### PR TITLE
fixing the mem/cpu perf issue due to utf8 lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .vscode
 *.wasm
 node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,12 @@
       "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "smart-deep-sort": "^1.0.2",
-        "sprintf-js": "^1.1.2",
-        "tmp": "^0.2.1",
-        "utf8": "^3.0.0"
+        "sprintf-js": "^1.1.2"
       },
       "devDependencies": {
         "jest": "^27.2.4",
+        "smart-deep-sort": "^1.0.2",
+        "tmp": "^0.2.1",
         "typescript": "^4.4.3"
       }
     },
@@ -1136,6 +1135,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
       "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+      "dev": true,
       "dependencies": {
         "default-compare": "^1.0.0",
         "get-value": "^2.0.6",
@@ -1149,6 +1149,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
       "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1254,12 +1255,14 @@
     "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1446,7 +1449,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
@@ -1548,6 +1552,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/deep-sort-object/-/deep-sort-object-1.0.2.tgz",
       "integrity": "sha1-OJLc7139Dvwtb6lr6rzLM82O+R8=",
+      "dev": true,
       "dependencies": {
         "is-plain-object": "^2.0.1"
       }
@@ -1565,6 +1570,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
       "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
+      "dev": true,
       "dependencies": {
         "kind-of": "^5.0.2"
       },
@@ -1576,6 +1582,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
       "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1847,7 +1854,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -1912,14 +1920,16 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2066,6 +2076,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2074,7 +2085,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/is-ci": {
       "version": "3.0.0",
@@ -2131,6 +2143,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -2172,6 +2185,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3105,6 +3119,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3182,6 +3197,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -3273,6 +3289,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3451,6 +3468,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -3540,6 +3558,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/smart-deep-sort/-/smart-deep-sort-1.0.2.tgz",
       "integrity": "sha512-vs1FP95Q7zj9KqlKN+B7KeCTaU4E81PFsKTlBnZh+H+9iFiJVGzCLIRGZfLIJ+B5EqVUvjU4VB3iVpobGf0h9A==",
+      "dev": true,
       "dependencies": {
         "array-sort": "^1.0.0",
         "deep-sort-object": "^1.0.2",
@@ -3550,7 +3569,8 @@
     "node_modules/sorty": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/sorty/-/sorty-1.2.2.tgz",
-      "integrity": "sha1-enI0aORitDIHc9M4e0yNolhHR6Y="
+      "integrity": "sha1-enI0aORitDIHc9M4e0yNolhHR6Y=",
+      "dev": true
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -3716,6 +3736,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
       "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dev": true,
       "dependencies": {
         "rimraf": "^3.0.0"
       },
@@ -3834,7 +3855,8 @@
     "node_modules/underscore": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -3844,11 +3866,6 @@
       "engines": {
         "node": ">= 4.0.0"
       }
-    },
-    "node_modules/utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.0",
@@ -3985,7 +4002,8 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -4961,6 +4979,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
       "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+      "dev": true,
       "requires": {
         "default-compare": "^1.0.0",
         "get-value": "^2.0.6",
@@ -4970,7 +4989,8 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
         }
       }
     },
@@ -5054,12 +5074,14 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5204,7 +5226,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "convert-source-map": {
       "version": "1.8.0",
@@ -5291,6 +5314,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/deep-sort-object/-/deep-sort-object-1.0.2.tgz",
       "integrity": "sha1-OJLc7139Dvwtb6lr6rzLM82O+R8=",
+      "dev": true,
       "requires": {
         "is-plain-object": "^2.0.1"
       }
@@ -5305,6 +5329,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
       "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
+      "dev": true,
       "requires": {
         "kind-of": "^5.0.2"
       },
@@ -5312,7 +5337,8 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
         }
       }
     },
@@ -5511,7 +5537,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "2.3.2",
@@ -5553,12 +5580,14 @@
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
     },
     "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5666,6 +5695,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5674,7 +5704,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "is-ci": {
       "version": "3.0.0",
@@ -5716,6 +5747,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -5747,7 +5779,8 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -6466,6 +6499,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -6531,6 +6565,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -6597,7 +6632,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -6730,6 +6766,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -6798,6 +6835,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/smart-deep-sort/-/smart-deep-sort-1.0.2.tgz",
       "integrity": "sha512-vs1FP95Q7zj9KqlKN+B7KeCTaU4E81PFsKTlBnZh+H+9iFiJVGzCLIRGZfLIJ+B5EqVUvjU4VB3iVpobGf0h9A==",
+      "dev": true,
       "requires": {
         "array-sort": "^1.0.0",
         "deep-sort-object": "^1.0.2",
@@ -6808,7 +6846,8 @@
     "sorty": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/sorty/-/sorty-1.2.2.tgz",
-      "integrity": "sha1-enI0aORitDIHc9M4e0yNolhHR6Y="
+      "integrity": "sha1-enI0aORitDIHc9M4e0yNolhHR6Y=",
+      "dev": true
     },
     "source-map": {
       "version": "0.6.1",
@@ -6938,6 +6977,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
       "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dev": true,
       "requires": {
         "rimraf": "^3.0.0"
       }
@@ -7022,18 +7062,14 @@
     "underscore": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+      "dev": true
     },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
-    },
-    "utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
     },
     "v8-to-istanbul": {
       "version": "8.1.0",
@@ -7142,7 +7178,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -28,12 +28,11 @@
   "homepage": "https://github.com/open-policy-agent/npm-opa-wasm#readme",
   "devDependencies": {
     "jest": "^27.2.4",
+    "smart-deep-sort": "^1.0.2",
+    "tmp": "^0.2.1",
     "typescript": "^4.4.3"
   },
   "dependencies": {
-    "smart-deep-sort": "^1.0.2",
-    "sprintf-js": "^1.1.2",
-    "tmp": "^0.2.1",
-    "utf8": "^3.0.0"
+    "sprintf-js": "^1.1.2"
   }
 }

--- a/test/fixtures/data-stress/.gitignore
+++ b/test/fixtures/data-stress/.gitignore
@@ -1,0 +1,2 @@
+bundle.tar.gz
+policy.wasm

--- a/test/fixtures/data-stress/base-data.json
+++ b/test/fixtures/data-stress/base-data.json
@@ -1,0 +1,77 @@
+{
+  "static": {
+    "roles": {
+      "1": {
+        "id": 1,
+        "name": "superuser",
+        "permissions": [
+          {
+            "id": "account_billing_information",
+            "priv": "view",
+            "type": "ui_element"
+          },
+          {
+            "id": "account_billing_information_1",
+            "priv": "execute",
+            "type": "rest_api"
+          },
+          {
+            "id": "account_billing_information_2",
+            "priv": "manage",
+            "type": "component"
+          },
+          {
+            "id": "account_billing_information_3",
+            "priv": "view",
+            "type": "ui_element"
+          },
+          {
+            "id": "account_billing_information_4",
+            "priv": "execute",
+            "type": "ui_element"
+          },
+          {
+            "id": "account_billing_information_5",
+            "priv": "execute",
+            "type": "rest_api"
+          },
+          {
+            "id": "account_billing_information_6",
+            "priv": "execute",
+            "type": "ui_element"
+          },
+          {
+            "id": "account_billing_information_7",
+            "priv": "view",
+            "type": "ui_element"
+          },
+          {
+            "id": "account_billing_information_8",
+            "priv": "view",
+            "type": "ui_element"
+          },
+          {
+            "id": "account_billing_information_9",
+            "priv": "execute",
+            "type": "rest_api"
+          },
+          {
+            "id": "account_billing_information_10",
+            "priv": "exercise",
+            "type": "rest_api"
+          },
+          {
+            "id": "account_billing_information_11",
+            "priv": "invoke",
+            "type": "rest_api"
+          },
+          {
+            "id": "account_billing_information_12",
+            "priv": "view",
+            "type": "ui_element"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/data-stress/example-one.rego
+++ b/test/fixtures/data-stress/example-one.rego
@@ -1,0 +1,19 @@
+package example.one
+
+import input
+
+default myRule = false
+default myOtherRule = false
+
+myRule {
+    input.someProp == "thisValue"
+}
+
+myOtherRule {
+    input.anotherProp == "thatValue"
+}
+
+myCompositeRule {
+    myRule
+    myOtherRule
+}

--- a/test/opa-large-data.test.js
+++ b/test/opa-large-data.test.js
@@ -1,0 +1,80 @@
+const { EOL } = require("os");
+const { readFileSync } = require("fs");
+const { execFileSync } = require("child_process");
+const { loadPolicy } = require("../src/opa.js");
+
+describe("setData stress tests", () => {
+  const baseDataRaw = readFileSync(
+    "test/fixtures/data-stress/base-data.json",
+    "utf-8",
+  );
+  const baseData = JSON.parse(baseDataRaw);
+
+  let data;
+
+  const multiplyFactor = 50000;
+  data = multiplyData(baseData, multiplyFactor);
+  const dataSize = multiplyFactor / 1000;
+
+  beforeAll(() => {
+    try {
+      execFileSync("opa", [
+        "build",
+        `test/fixtures/data-stress`,
+        "-o",
+        `test/fixtures/data-stress/bundle.tar.gz`,
+        "-t",
+        "wasm",
+        "-e",
+        "example",
+        "-e",
+        "example/one",
+      ]);
+
+      execFileSync("tar", [
+        "-xzf",
+        `test/fixtures/data-stress/bundle.tar.gz`,
+        "-C",
+        `test/fixtures/data-stress/`,
+        `/policy.wasm`,
+      ]);
+    } catch (err) {
+      console.error("Error creating test binary, check that opa is in path");
+      throw err;
+    }
+  });
+
+  it(`setData of size ~${dataSize}Mb`, async () => {
+    const policyWasm = readFileSync("test/fixtures/data-stress/policy.wasm");
+    const policy = await loadPolicy(policyWasm, 32000);
+
+    const start = Date.now();
+
+    policy.setData(data);
+    data = null;
+
+    const end = Date.now();
+    console.log(`setData of ~${dataSize}Mb took ${end - start}ms`);
+
+    if (globalThis.gc) {
+      globalThis.gc();
+    }
+    dumpMemoryUsage(`memory status AFTER setData ~${dataSize}Mb`);
+  });
+});
+
+function multiplyData(input, count) {
+  const result = {};
+  for (let i = 0, l = count; i < l; i++) {
+    result[`static${i}`] = input.static;
+  }
+  return result;
+}
+
+function dumpMemoryUsage(note) {
+  process.stdout.write(`Memory dump: ${note}${EOL}`);
+  for (const [key, value] of Object.entries(process.memoryUsage())) {
+    process.stdout.write(`\t${key}: ${value / 1000000} MB${EOL}`);
+  }
+  process.stdout.write(EOL);
+}


### PR DESCRIPTION
This PR deals with performance issues caused by usage of 'utf8' lib, which nowadays may be replaced by natively supported `TextEncoder` and `TextDecoder`.

The performance penalty was observed while using in some domestic flow with large data set (~100Mb).

Rough report of reproduced issue may be found here: https://github.com/gullerya/npm-opa-wasm/blob/json-processing-perf-impr/test/fixtures/data-stress/before-fix-observations.md

Another small suggestion implemented in this PR is to allow `setData` API to accept already stringified JSON, which might be the quite common flow assuming that consumer application brings data from the network or local file.