### PR TITLE
[issue 80] Allow use of stringified data/input

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,20 @@ javascript context through external APIs.
 The loaded policy object returned from `loadPolicy()` has a couple of important
 APIs for policy evaluation:
 
-`setData(obj)` -- Provide an external `data` document for policy evaluation.
-Requires a JSON serializable object. `evaluate(input)` -- Evaluates the policy
-using any loaded data and the supplied `input` document.
+`setData(data)` -- Provide an external `data` document for policy evaluation.
 
-The `input` parameter must be a JSON string.
+- `data` MUST be a serializable object or `ArrayBuffer`, which assumed to be a
+  well-formed stringified JSON
+
+`evaluate(input)` -- Evaluates the policy using any loaded data and the supplied
+`input` document.
+
+- `input` parameter MAY be an `object`, primitive literal or `ArrayBuffer`,
+  which assumed to be a well-formed stringified JSON
+
+> `ArrayBuffer` supported in the APIs above as a performance optimisation
+> feature, given that either network or file system provided contents can easily
+> be represented as `ArrayBuffer` in a very performant way.
 
 Example:
 

--- a/test/fixtures/data-stress/example-one.rego
+++ b/test/fixtures/data-stress/example-one.rego
@@ -1,7 +1,5 @@
 package example.one
 
-import input
-
 default myRule = false
 default myOtherRule = false
 

--- a/test/fixtures/multiple-entrypoints/example-one.rego
+++ b/test/fixtures/multiple-entrypoints/example-one.rego
@@ -1,7 +1,5 @@
 package example.one
 
-import input
-
 default myRule = false
 default myOtherRule = false
 

--- a/test/fixtures/multiple-entrypoints/example-two.rego
+++ b/test/fixtures/multiple-entrypoints/example-two.rego
@@ -1,7 +1,5 @@
 package example.two
 
-import input
-
 default theirRule = false
 default ourRule = false
 

--- a/test/fixtures/stringified-support/.gitignore
+++ b/test/fixtures/stringified-support/.gitignore
@@ -1,0 +1,2 @@
+bundle.tar.gz
+policy.wasm

--- a/test/fixtures/stringified-support/stringified-support-data.json
+++ b/test/fixtures/stringified-support/stringified-support-data.json
@@ -1,0 +1,16 @@
+{
+  "roles": {
+    "1": {
+      "id": 1,
+      "permissions": [
+        {
+          "id": "view:account-billing"
+        },
+        {
+          "id": "edit:account-billing"
+        }
+      ]
+    }
+  },
+  "secret": "secret"
+}

--- a/test/fixtures/stringified-support/stringified-support-policy.rego
+++ b/test/fixtures/stringified-support/stringified-support-policy.rego
@@ -1,0 +1,26 @@
+package stringified.support
+
+default hasPermission = false
+default plainInputBoolean = false
+default plainInputNumber = false
+default plainInputString = false
+
+hasPermission {
+    input.secret == data.secret
+}
+
+hasPermission {
+    input.permissions[_] == data.roles["1"].permissions[_].id
+}
+
+plainInputBoolean {
+    input = true
+}
+
+plainInputNumber {
+    input = 5
+}
+
+plainInputString {
+    input = "test"
+}

--- a/test/opa-large-data.test.js
+++ b/test/opa-large-data.test.js
@@ -2,6 +2,7 @@ const { EOL } = require("os");
 const { readFileSync } = require("fs");
 const { execFileSync } = require("child_process");
 const { loadPolicy } = require("../src/opa.js");
+const util = require("util");
 
 describe("setData stress tests", () => {
   const baseDataRaw = readFileSync(
@@ -11,10 +12,13 @@ describe("setData stress tests", () => {
   const baseData = JSON.parse(baseDataRaw);
 
   let data;
+  let dataBuf;
 
-  const multiplyFactor = 50000;
-  data = multiplyData(baseData, multiplyFactor);
-  const dataSize = multiplyFactor / 1000;
+  const multiplyFactor = 50;
+  data = multiplyData(baseData, multiplyFactor * 1000);
+  dataBuf = new util.TextEncoder().encode(JSON.stringify(data)).buffer;
+  data = null;
+  const dataSize = dataBuf.byteLength / 1000000;
 
   beforeAll(() => {
     try {
@@ -50,8 +54,8 @@ describe("setData stress tests", () => {
 
     const start = Date.now();
 
-    policy.setData(data);
-    data = null;
+    policy.setData(dataBuf);
+    dataBuf = null;
 
     const end = Date.now();
     console.log(`setData of ~${dataSize}Mb took ${end - start}ms`);

--- a/test/opa-stringified-support.test.js
+++ b/test/opa-stringified-support.test.js
@@ -1,0 +1,121 @@
+const { readFileSync } = require("fs");
+const { execFileSync } = require("child_process");
+const { loadPolicy } = require("../src/opa.js");
+const util = require("util");
+
+describe("stringified data/input support", () => {
+  const fixturesFolder = "test/fixtures/stringified-support";
+  const dataRaw = readFileSync(
+    `${fixturesFolder}/stringified-support-data.json`,
+    "utf-8",
+  );
+  const data = JSON.parse(dataRaw);
+
+  let policy;
+
+  beforeAll(async () => {
+    const bundlePath = `${fixturesFolder}/bundle.tar.gz`;
+
+    execFileSync("opa", [
+      "build",
+      fixturesFolder,
+      "-o",
+      bundlePath,
+      "-t",
+      "wasm",
+      "-e",
+      "stringified/support",
+      "-e",
+      "stringified/support/plainInputBoolean",
+      "-e",
+      "stringified/support/plainInputNumber",
+      "-e",
+      "stringified/support/plainInputString",
+    ]);
+
+    execFileSync("tar", [
+      "-xzf",
+      bundlePath,
+      "-C",
+      `${fixturesFolder}/`,
+      "/policy.wasm",
+    ]);
+
+    const policyWasm = readFileSync(`${fixturesFolder}/policy.wasm`);
+    policy = await loadPolicy(policyWasm);
+  });
+
+  it("should accept stringified data", () => {
+    policy.setData(new util.TextEncoder().encode(dataRaw).buffer);
+
+    //  positive check
+    let result = policy.evaluate({ secret: "secret" });
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({ result: { hasPermission: true } });
+
+    //  negative check
+    result = policy.evaluate({ secret: "wrong" });
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({ result: { hasPermission: false } });
+  });
+
+  it("should accept stringified input - object", () => {
+    policy.setData(data);
+
+    //  positive check
+    let result = policy.evaluate(
+      new util.TextEncoder().encode(
+        JSON.stringify({ permissions: ["view:account-billing"] }),
+      ).buffer,
+    );
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({ result: { hasPermission: true } });
+
+    //  negative check
+    result = policy.evaluate(JSON.stringify({ secret: "wrong" }));
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({ result: { hasPermission: false } });
+  });
+
+  it("should accept stringified input - plain boolean", () => {
+    //  positive check
+    let result = policy.evaluate(true, "stringified/support/plainInputBoolean");
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({ result: true });
+
+    //  negative check
+    result = policy.evaluate(false, "stringified/support/plainInputBoolean");
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({ result: false });
+  });
+
+  it("should accept stringified input - plain number", () => {
+    //  positive check
+    let result = policy.evaluate(5, "stringified/support/plainInputNumber");
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({ result: true });
+
+    //  negative check
+    result = policy.evaluate(6, "stringified/support/plainInputNumber");
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({ result: false });
+  });
+
+  it("should accept stringified input - plain string", () => {
+    //  positive check
+    let result = policy.evaluate(
+      "test",
+      "stringified/support/plainInputString",
+    );
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({ result: true });
+
+    //  negative check
+    result = policy.evaluate(
+      "invalid",
+      "stringified/support/plainInputString",
+    );
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({ result: false });
+  });
+});


### PR DESCRIPTION
This PR aims:
- to allow supply of already stringified data to `setData` API (performance targeted)
- to allow supply of already stringified input to `evaluate` API (performance targeted)

The `setData` API handles the non-JSON strings correctly, by throwing a corresponding error.
The `evaluate` API has no such validation, which looks to me as on purpose, but we can discuss it.

Any considerations/suggestions are welcome.