### PR TITLE
feat: add support for yaml.unmarshal builtin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "sprintf-js": "^1.1.2"
+        "sprintf-js": "^1.1.2",
+        "yaml": "^1.10.2"
       },
       "devDependencies": {
         "jest": "^27.2.4",
@@ -4115,6 +4116,14 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -7313,6 +7322,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
-    "sprintf-js": "^1.1.2"
+    "sprintf-js": "^1.1.2",
+    "yaml": "^1.10.2"
   }
 }

--- a/src/builtins/index.js
+++ b/src/builtins/index.js
@@ -1,7 +1,9 @@
 const strings = require("./strings");
 const regex = require("./regex");
+const yaml = require("./yaml");
 
 module.exports = {
   ...strings,
   ...regex,
+  ...yaml,
 };

--- a/src/builtins/yaml.js
+++ b/src/builtins/yaml.js
@@ -1,0 +1,28 @@
+const yaml = require("yaml");
+
+// see: https://eemeli.org/yaml/v1/#errors
+const errors = new Set([
+  "YAMLReferenceError",
+  "YAMLSemanticError",
+  "YAMLSyntaxError",
+  "YAMLWarning",
+]);
+
+const unmarshal = function (str) {
+  const YAML_SILENCE_WARNINGS_CACHED = global.YAML_SILENCE_WARNINGS;
+  try {
+    // see: https://eemeli.org/yaml/v1/#silencing-warnings
+    global.YAML_SILENCE_WARNINGS = true;
+    return yaml.parse(str);
+  } catch (err) {
+    // Ignore parser errors.
+    if (err && errors.has(err.name)) {
+      return false;
+    }
+    throw err;
+  } finally {
+    global.YAML_SILENCE_WARNINGS = YAML_SILENCE_WARNINGS_CACHED;
+  }
+};
+
+module.exports = { "yaml.unmarshal": unmarshal };

--- a/test/fixtures/yaml-support/.gitignore
+++ b/test/fixtures/yaml-support/.gitignore
@@ -1,0 +1,2 @@
+bundle.tar.gz
+policy.wasm

--- a/test/fixtures/yaml-support/yaml-support-policy.rego
+++ b/test/fixtures/yaml-support/yaml-support-policy.rego
@@ -1,0 +1,50 @@
+package yaml.support
+
+fixture := `
+---
+openapi: "3.0.1"
+info:
+  title: test
+paths:
+  /path1:
+    get:
+      x-amazon-apigateway-integration:
+        type: "mock"
+        httpMethod: "GET"
+x-amazon-apigateway-policy:
+  Version: "2012-10-17"
+  Statement:
+    - Effect: Allow
+      Principal:
+        AWS: "*"
+      Action:
+        - 'execute-api:Invoke'
+      Resource: '*'
+`
+
+default canParseYaml = false
+
+canParseYAML {
+	resource := yaml.unmarshal(fixture)
+	resource.info.title == "test"
+}
+
+hasSemanticError {
+	# see: https://github.com/eemeli/yaml/blob/395f892ec9a26b9038c8db388b675c3281ab8cd3/tests/doc/errors.js#L22
+	yaml.unmarshal("a:\n\t1\nb:\n\t2\n")
+}
+
+hasSyntaxError {
+	# see: https://github.com/eemeli/yaml/blob/395f892ec9a26b9038c8db388b675c3281ab8cd3/tests/doc/errors.js#L49
+	yaml.unmarshal("{ , }\n---\n{ 123,,, }\n")
+}
+
+hasReferenceError {
+	# see: https://github.com/eemeli/yaml/blob/395f892ec9a26b9038c8db388b675c3281ab8cd3/tests/doc/errors.js#L245
+	yaml.unmarshal("{ , }\n---\n{ 123,,, }\n")
+}
+
+hasYAMLWarning {
+	# see: https://github.com/eemeli/yaml/blob/395f892ec9a26b9038c8db388b675c3281ab8cd3/tests/doc/errors.js#L224
+	yaml.unmarshal("%FOO\n---bar\n")
+}

--- a/test/opa-yaml-support.test.js
+++ b/test/opa-yaml-support.test.js
@@ -1,0 +1,78 @@
+const { readFileSync } = require("fs");
+const { execFileSync } = require("child_process");
+const { loadPolicy } = require("../src/opa.js");
+
+describe("yaml.unmarshal() support", () => {
+  const fixturesFolder = "test/fixtures/yaml-support";
+
+  let policy;
+
+  beforeAll(async () => {
+    const bundlePath = `${fixturesFolder}/bundle.tar.gz`;
+
+    execFileSync("opa", [
+      "build",
+      fixturesFolder,
+      "-o",
+      bundlePath,
+      "-t",
+      "wasm",
+      "-e",
+      "yaml/support/canParseYAML",
+      "-e",
+      "yaml/support/hasSyntaxError",
+      "-e",
+      "yaml/support/hasSemanticError",
+      "-e",
+      "yaml/support/hasReferenceError",
+      "-e",
+      "yaml/support/hasYAMLWarning",
+    ]);
+
+    execFileSync("tar", [
+      "-xzf",
+      bundlePath,
+      "-C",
+      `${fixturesFolder}/`,
+      "/policy.wasm",
+    ]);
+
+    const policyWasm = readFileSync(`${fixturesFolder}/policy.wasm`);
+    const opts = { initial: 5, maximum: 10 };
+    policy = await loadPolicy(policyWasm, opts);
+  });
+
+  it("should unmarshall YAML strings", () => {
+    const result = policy.evaluate({}, "yaml/support/canParseYAML");
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({ result: true });
+  });
+
+  it("should ignore YAML syntax errors", () => {
+    expect(() => policy.evaluate({}, "yaml/support/hasSyntaxError")).not
+      .toThrow();
+    const result = policy.evaluate({}, "yaml/support/hasSyntaxError");
+    expect(result.length).toBe(0);
+  });
+
+  it("should ignore YAML semantic errors", () => {
+    expect(() => policy.evaluate({}, "yaml/support/hasSemanticError")).not
+      .toThrow();
+    const result = policy.evaluate({}, "yaml/support/hasSemanticError");
+    expect(result.length).toBe(0);
+  });
+
+  it("should ignore YAML reference errors", () => {
+    expect(() => policy.evaluate({}, "yaml/support/hasReferenceError")).not
+      .toThrow();
+    const result = policy.evaluate({}, "yaml/support/hasReferenceError");
+    expect(result.length).toBe(0);
+  });
+
+  it("should ignore YAML warnings", () => {
+    expect(() => policy.evaluate({}, "yaml/support/hasYAMLWarning")).not
+      .toThrow();
+    const result = policy.evaluate({}, "yaml/support/hasYAMLWarning");
+    expect(result.length).toBe(0);
+  });
+});


### PR DESCRIPTION
This uses the "yaml" npm package to provide support for unmarshalling YAML strings within rego via the `yaml.unmarshal()` function. The implementation itself is straightforward. I've added the src/builtins/yaml.js file as per the strings.js example and exposed the `yaml.parse()` function under the `"yaml.unmarshal"` key. 

There's a bit of awkwardness to silence the default warnings emitted by the "yaml" library which required setting a `YAML_SILENCE_WARNINGS` global and then resetting it to avoid conflicts.

Choices for YAML parser in the JS ecosystem seem to fall between [yaml](https://www.npmjs.com/package/yaml) and [js-yaml](https://www.npmjs.com/package/js-yaml). Both are actively maintained. I went with `yaml` because it has zero dependencies and in our testing at Snyk on a wide variety of YAML fixtures it has the closest alignment with the ghodss/yaml YAML library used by OPA.

Test functionality has been included in the test/opa-yaml-support.test.js file. This verifies parsing of a generic YAML structure. Handling of syntax, metadata, reference and warnings has also been exercised using fixtures from the [yaml test suite](https://github.com/eemeli/yaml/blob/v1/tests/doc/errors.js), these are all ignored.

I've run the `fmt` and `lint` commands on the source as well as `opa fmt` on the rego fixtures.