### PR TITLE
Add support for yaml.marshal and yaml.is_valid

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -896,6 +896,20 @@
       }
     },
     {
+      "name": "json.is_valid",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
       "name": "json.marshal",
       "decl": {
         "args": [

--- a/capabilities.json
+++ b/capabilities.json
@@ -2072,6 +2072,48 @@
         "type": "function"
       },
       "relation": true
+    },
+    {
+      "name": "yaml.is_valid",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "yaml.marshal",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
+      "name": "yaml.unmarshal",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "any"
+        },
+        "type": "function"
+      }
     }
   ],
   "wasm_abi_versions": [

--- a/src/builtins/index.js
+++ b/src/builtins/index.js
@@ -1,8 +1,10 @@
+const json = require("./json");
 const strings = require("./strings");
 const regex = require("./regex");
 const yaml = require("./yaml");
 
 module.exports = {
+  ...json,
   ...strings,
   ...regex,
   ...yaml,

--- a/src/builtins/json.js
+++ b/src/builtins/json.js
@@ -1,0 +1,18 @@
+function isValidJSON(str) {
+  if (typeof str !== "string") {
+    return;
+  }
+  try {
+    JSON.parse(str);
+    return true;
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+module.exports = {
+  "json.is_valid": isValidJSON,
+};

--- a/src/builtins/yaml.js
+++ b/src/builtins/yaml.js
@@ -8,21 +8,31 @@ const errors = new Set([
   "YAMLWarning",
 ]);
 
-const unmarshal = function (str) {
+function parse(str) {
+  if (typeof str !== "string") {
+    return { ok: false, result: undefined };
+  }
+
   const YAML_SILENCE_WARNINGS_CACHED = global.YAML_SILENCE_WARNINGS;
   try {
     // see: https://eemeli.org/yaml/v1/#silencing-warnings
     global.YAML_SILENCE_WARNINGS = true;
-    return yaml.parse(str);
+    return { ok: true, result: yaml.parse(str) };
   } catch (err) {
     // Ignore parser errors.
     if (err && errors.has(err.name)) {
-      return false;
+      return { ok: false, result: undefined };
     }
     throw err;
   } finally {
     global.YAML_SILENCE_WARNINGS = YAML_SILENCE_WARNINGS_CACHED;
   }
-};
+}
 
-module.exports = { "yaml.unmarshal": unmarshal };
+module.exports = {
+  // is_valid is expected to return nothing if input is invalid otherwise
+  // true/false for it being valid YAML.
+  "yaml.is_valid": (str) => typeof str === "string" ? parse(str).ok : undefined,
+  "yaml.marshal": (data) => yaml.stringify(data),
+  "yaml.unmarshal": (str) => parse(str).result,
+};

--- a/test/fixtures/yaml-support/yaml-support-policy.rego
+++ b/test/fixtures/yaml-support/yaml-support-policy.rego
@@ -22,8 +22,6 @@ x-amazon-apigateway-policy:
       Resource: '*'
 `
 
-default canParseYaml = false
-
 canParseYAML {
 	resource := yaml.unmarshal(fixture)
 	resource.info.title == "test"
@@ -47,4 +45,15 @@ hasReferenceError {
 hasYAMLWarning {
 	# see: https://github.com/eemeli/yaml/blob/395f892ec9a26b9038c8db388b675c3281ab8cd3/tests/doc/errors.js#L224
 	yaml.unmarshal("%FOO\n---bar\n")
+}
+
+canMarshalYAML[x] {
+	string := yaml.marshal(input)
+	x := yaml.unmarshal(string)
+}
+
+isValidYAML {
+	yaml.is_valid(fixture) == true
+	yaml.is_valid("foo: {") == false
+	yaml.is_valid("{\"foo\": \"bar\"}") == true
 }

--- a/test/opa-test-cases.test.js
+++ b/test/opa-test-cases.test.js
@@ -2,7 +2,7 @@ const { readFileSync, readdirSync, writeFileSync } = require("fs");
 const { execFileSync, spawnSync } = require("child_process");
 const { join } = require("path");
 const { loadPolicy } = require("../src/opa.js");
-const yaml = require("js-yaml");
+const yaml = require("yaml");
 const tmp = require("tmp");
 const sort = require("smart-deep-sort");
 
@@ -42,8 +42,7 @@ function compileToWasm(modules, query) {
   if (modules && modules.length < 1) {
     return {
       skip: `empty modules cases are not supported (got ${
-        modules &&
-        modules.length
+        modules && modules.length
       })`,
     };
   }
@@ -95,7 +94,7 @@ if (path === undefined) {
 } else {
   for (const file of walk(path)) {
     describe(file, () => {
-      const doc = yaml.load(readFileSync(file, "utf8"));
+      const doc = yaml.parse(readFileSync(file, "utf8"));
       cases:
       for (const tc of doc.cases) {
         const reason = exceptions[tc.note];
@@ -118,8 +117,7 @@ if (path === undefined) {
         if (tc.want_result && tc.want_result.length > 1) {
           test.todo(
             `${tc.note}: more than one expected result not supported: ${
-              tc
-                .want_result && tc.want_result.length
+              tc.want_result && tc.want_result.length
             }`,
           );
           continue cases;

--- a/test/opa-yaml-support.test.js
+++ b/test/opa-yaml-support.test.js
@@ -2,7 +2,7 @@ const { readFileSync } = require("fs");
 const { execFileSync } = require("child_process");
 const { loadPolicy } = require("../src/opa.js");
 
-describe("yaml.unmarshal() support", () => {
+describe("yaml support", () => {
   const fixturesFolder = "test/fixtures/yaml-support";
 
   let policy;
@@ -27,6 +27,10 @@ describe("yaml.unmarshal() support", () => {
       "yaml/support/hasReferenceError",
       "-e",
       "yaml/support/hasYAMLWarning",
+      "-e",
+      "yaml/support/canMarshalYAML",
+      "-e",
+      "yaml/support/isValidYAML",
     ]);
 
     execFileSync("tar", [
@@ -74,5 +78,20 @@ describe("yaml.unmarshal() support", () => {
       .toThrow();
     const result = policy.evaluate({}, "yaml/support/hasYAMLWarning");
     expect(result.length).toBe(0);
+  });
+
+  it("should marshal yaml", () => {
+    const result = policy.evaluate(
+      [{ foo: [1, 2, 3] }],
+      "yaml/support/canMarshalYAML",
+    );
+    expect(result.length).toBe(1);
+    expect(result[0]).toMatchObject({ result: [[{ foo: [1, 2, 3] }]] });
+  });
+
+  it("should validate yaml", () => {
+    const result = policy.evaluate({}, "yaml/support/isValidYAML");
+    expect(result.length).toBe(1);
+    expect(result[0]).toMatchObject({ result: true });
   });
 });


### PR DESCRIPTION
This continues on the work done in #100 to add support for `yaml.unmarshal`. This PR implements the requested changes in that [thread](https://github.com/open-policy-agent/npm-opa-wasm/pull/100#issuecomment-991113533).

1. Adds the four yaml and json capabilities to the capabilities.json
2. Ensures the opa test cases are enabled and passing

As part of that I also implemented the other three functions `yaml.is_valid`, `yaml.marshal`, `json.is_valid` to ensure all the test cases pass as well as extending the local test suite.