### PR TITLE
Util require is not needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
   "dependencies": {
     "sprintf-js": "^1.1.2",
     "yaml": "^1.10.2"
+  },
+  "engines": {
+    "node": ">=10.0.0"
   }
 }

--- a/src/opa.js
+++ b/src/opa.js
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 const builtIns = require("./builtins/index");
-const util = require("util");
 
 /**
  * @param {WebAssembly.Memory} mem
@@ -35,7 +34,7 @@ function _loadJSON(wasmInstance, memory, value) {
     valueBuf = new Uint8Array(value);
   } else {
     const valueAsText = JSON.stringify(value);
-    valueBuf = new util.TextEncoder().encode(valueAsText);
+    valueBuf = new TextEncoder().encode(valueAsText);
   }
 
   const valueBufLen = valueBuf.byteLength;
@@ -79,7 +78,7 @@ function _dumpJSONRaw(memory, addr) {
   }
 
   const utf8View = new Uint8Array(memory.buffer, addr, idx - addr);
-  const jsonAsText = new util.TextDecoder().decode(utf8View);
+  const jsonAsText = new TextDecoder().decode(utf8View);
 
   return JSON.parse(jsonAsText);
 }
@@ -295,7 +294,7 @@ class LoadedPolicy {
           inputBuf = new Uint8Array(input);
         } else {
           const inputAsText = JSON.stringify(input);
-          inputBuf = new util.TextEncoder().encode(inputAsText);
+          inputBuf = new TextEncoder().encode(inputAsText);
         }
 
         inputAddr = this.dataHeapPtr;


### PR DESCRIPTION
TextEncoder and TextDecoder are native supported from Nodejs 10 and Nodejs 8.0 is not supported since 2020. It make sense to set Nodejs 10 as minimum supported version (engines in package.json). And then we can remove util require.

It also make this library available for browser environment that actually supports wasm too.