### PR TITLE
Support for Node 10.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x]
         opa-version:
         - 0.30.2 # last version with ABI 1.1, 0.31.0+ has ABI 1.2
         - 0.35.0 # first release with https://github.com/open-policy-agent/opa/pull/4055

--- a/src/opa.js
+++ b/src/opa.js
@@ -192,9 +192,13 @@ async function _loadPolicy(policyWasm, memory) {
     },
   });
 
+  // Note: On Node 10.x this value is a number on Node 12.x and up it is
+  // an object with numberic `value` property.
   const abiVersionGlobal = wasm.instance.exports.opa_wasm_abi_version;
   if (abiVersionGlobal !== undefined) {
-    const abiVersion = abiVersionGlobal.value;
+    const abiVersion = typeof abiVersionGlobal === "number"
+      ? abiVersionGlobal
+      : abiVersionGlobal.value;
     if (abiVersion !== 1) {
       throw `unsupported ABI version ${abiVersion}`;
     }
@@ -206,7 +210,9 @@ async function _loadPolicy(policyWasm, memory) {
     wasm.instance.exports.opa_wasm_abi_minor_version;
   let abiMinorVersion;
   if (abiMinorVersionGlobal !== undefined) {
-    abiMinorVersion = abiMinorVersionGlobal.value;
+    abiMinorVersion = typeof abiMinorVersionGlobal === "number"
+      ? abiMinorVersionGlobal
+      : abiMinorVersionGlobal.value;
   } else {
     console.error("opa_wasm_abi_minor_version undefined");
   }

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -33,13 +33,11 @@ describe("growing memory", () => {
       "test/allow",
     ]);
 
-    execFileSync("tar", [
-      "-xzf",
-      bundlePath,
-      "-C",
-      `${fixturesFolder}/`,
-      "/policy.wasm",
-    ], { stdio: "ignore" });
+    execFileSync(
+      "tar",
+      ["-xzf", bundlePath, "-C", `${fixturesFolder}/`, "/policy.wasm"],
+      { stdio: "ignore" },
+    );
 
     policyWasm = readFileSync(`${fixturesFolder}/policy.wasm`);
   });
@@ -47,8 +45,10 @@ describe("growing memory", () => {
   it("input exceeds memory, host fails to grow it", async () => {
     const policy = await loadPolicy(policyWasm, { initial: 2, maximum: 3 });
     const input = "a".repeat(2 * 65536);
+
+    // Note: In Node 10.x case is different
     expect(() => policy.evaluate(input)).toThrow(
-      "WebAssembly.Memory.grow(): Maximum memory size exceeded",
+      /WebAssembly\.Memory\.grow\(\): Maximum memory size exceeded/i,
     );
   });
 

--- a/test/opa-large-data.test.js
+++ b/test/opa-large-data.test.js
@@ -60,8 +60,9 @@ describe("setData stress tests", () => {
     const end = Date.now();
     console.log(`setData of ~${dataSize}Mb took ${end - start}ms`);
 
-    if (globalThis.gc) {
-      globalThis.gc();
+    if (global.gc) {
+      console.log("done");
+      global.gc();
     }
     dumpMemoryUsage(`memory status AFTER setData ~${dataSize}Mb`);
   });


### PR DESCRIPTION
I've run into an issue where version 1.2.0 of opa-wasm has lost support for Node 10. This is due to the change introduced in #45 to check for the `wasm.instance.exports.opa_wasm_abi_version`. On Node 12+ this value is returned as an object with a numeric `value` property. On Node 10 it's a numeric literal. This results in an `unsupported ABI version undefined` error when trying to load any module. Otherwise everything works as expected. I've not looked into detail for the reasons for the change, nothing is mentioned in the NodeJS wasm documentation.

I've opened this PR to fix the issue so that the tool supports Node 10.x, which required a type check on the `opa_wasm_abi_version` value in opa.js. I understand that Node 10 is an extremely old version that is already [past end-of-life](https://nodejs.org/en/about/releases/) so I'm not asking to officially support it but wondered if you'd consider taking on the patch regardless? At Snyk where we use opa-wasm in our CLI we're still currently committed to supporting Node 10 at least for the next quarter while we phase it out.

For the purposes of the PR I've enabled the test matrix to include Node 10, I propose that if you approve the change I'll revert the change to the GitHub action before merging. Cheers.