### PR TITLE
Add deno example, separate build steps, update deno version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: denoland/setup-deno@v1
       with:
-        deno-version: v1.15.0
+        deno-version: v1.17.2
     - uses: actions/checkout@v2
     - run: deno fmt --check
     - run: deno lint
@@ -71,4 +71,30 @@ jobs:
       env:
         OPA_CASES: test/cases/
         OPA_TEST_CASES: testdata
-    - run: ./e2e.sh
+
+  examples-node:
+    name: NodeJS examples
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: infracost/setup-opa@v1
+    - uses: actions/setup-node@v2.5.1
+      with:
+        node-version: "12"
+    - name: nodejs
+      run: >
+        npm ci
+        npm run build
+        ./e2e.sh
+
+  examples-deno:
+    name: Deno examples
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: infracost/setup-opa@v1
+    - uses: denoland/setup-deno@v1
+      with:
+        deno-version: v1.17.2
+    - run: make
+      working-directory: examples/deno

--- a/examples/deno/.gitignore
+++ b/examples/deno/.gitignore
@@ -1,0 +1,1 @@
+test.wasm

--- a/examples/deno/Makefile
+++ b/examples/deno/Makefile
@@ -1,0 +1,13 @@
+all: build run
+
+build: test.wasm
+
+test.wasm: test.rego
+	opa build -t wasm -e test/p $<
+	tar zxvf bundle.tar.gz /policy.wasm
+	mv policy.wasm test.wasm
+	touch test.wasm
+	rm bundle.tar.gz
+
+run:
+	deno run --allow-read=test.wasm main.ts

--- a/examples/deno/main.ts
+++ b/examples/deno/main.ts
@@ -1,0 +1,11 @@
+import opa from "https://unpkg.com/@open-policy-agent/opa-wasm@1.6.0/dist/opa-wasm-browser.esm.js";
+
+const file = await Deno.readFile("test.wasm");
+const policy = await opa.loadPolicy(file.buffer.slice(0, file.length));
+const input = { "foo": "bar" };
+
+const result = policy.evaluate(input);
+
+if (!result[0]?.result) {
+  Deno.exit(1);
+}

--- a/examples/deno/test.rego
+++ b/examples/deno/test.rego
@@ -1,0 +1,5 @@
+package test
+
+p {
+    input.foo == "bar"
+}

--- a/src/index.cjs
+++ b/src/index.cjs
@@ -1,1 +1,1 @@
-module.exports = require('./opa');
+module.exports = require("./opa");


### PR DESCRIPTION
Using deno was enabled by https://github.com/open-policy-agent/npm-opa-wasm/pull/110.
