### PR TITLE
support customBuiltins parameter in loadPolicy

### DIFF
--- a/test/fixtures/custom-builtins/capabilities.json
+++ b/test/fixtures/custom-builtins/capabilities.json
@@ -1,0 +1,98 @@
+{
+  "builtins": [
+    {
+      "name": "custom.zeroArgBuiltin",
+      "decl": {
+        "type": "function",
+        "args": [],
+        "result": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "name": "custom.oneArgBuiltin",
+      "decl": {
+        "type": "function",
+        "args": [
+          { "type": "string" }
+        ],
+        "result": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "name": "custom.twoArgBuiltin",
+      "decl": {
+        "type": "function",
+        "args": [
+          { "type": "string" },
+          { "type": "string" }
+        ],
+        "result": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "name": "custom.threeArgBuiltin",
+      "decl": {
+        "type": "function",
+        "args": [
+          { "type": "string" },
+          { "type": "string" },
+          { "type": "string" }
+        ],
+        "result": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "name": "custom.fourArgBuiltin",
+      "decl": {
+        "type": "function",
+        "args": [
+          { "type": "string" },
+          { "type": "string" },
+          { "type": "string" },
+          { "type": "string" }
+        ],
+        "result": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "name": "json.is_valid",
+      "decl": {
+        "type": "function",
+        "args": [
+          { "type": "string" }
+        ],
+        "result": {
+          "type": "boolean"
+        }
+      }
+    },
+    {
+      "name": "eq",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          },
+          {
+            "type": "any"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      },
+      "infix": "="
+    }
+  ]
+}

--- a/test/fixtures/custom-builtins/custom-builtins-policy.rego
+++ b/test/fixtures/custom-builtins/custom-builtins-policy.rego
@@ -1,0 +1,25 @@
+package custom_builtins
+
+zero_arg = x {
+  x = custom.zeroArgBuiltin()
+}
+
+one_arg = x {
+    x = custom.oneArgBuiltin(input.args[0])
+}
+
+two_arg = x {
+    x = custom.twoArgBuiltin(input.args[0], input.args[1])
+}
+
+three_arg = x {
+    x = custom.threeArgBuiltin(input.args[0], input.args[1], input.args[2])
+}
+
+four_arg = x {
+    x = custom.fourArgBuiltin(input.args[0], input.args[1], input.args[2], input.args[3])
+}
+
+valid_json {
+    json.is_valid("{}")
+}

--- a/test/opa-custom-builtins.test.js
+++ b/test/opa-custom-builtins.test.js
@@ -1,0 +1,115 @@
+const { readFileSync } = require("fs");
+const { execFileSync } = require("child_process");
+const { loadPolicy } = require("../src/opa.js");
+
+describe("custom builtins", () => {
+  const fixturesFolder = "test/fixtures/custom-builtins";
+
+  let policy;
+
+  beforeAll(async () => {
+    const bundlePath = `${fixturesFolder}/bundle.tar.gz`;
+
+    execFileSync("opa", [
+      "build",
+      fixturesFolder,
+      "-o",
+      bundlePath,
+      "-t",
+      "wasm",
+      "--capabilities",
+      `${fixturesFolder}/capabilities.json`,
+      "-e",
+      "custom_builtins/zero_arg",
+      "-e",
+      "custom_builtins/one_arg",
+      "-e",
+      "custom_builtins/two_arg",
+      "-e",
+      "custom_builtins/three_arg",
+      "-e",
+      "custom_builtins/four_arg",
+      "-e",
+      "custom_builtins/valid_json",
+    ]);
+
+    execFileSync("tar", [
+      "-xzf",
+      bundlePath,
+      "-C",
+      `${fixturesFolder}/`,
+      "/policy.wasm",
+    ]);
+
+    const policyWasm = readFileSync(`${fixturesFolder}/policy.wasm`);
+    const opts = { initial: 5, maximum: 10 };
+    policy = await loadPolicy(policyWasm, opts, {
+      "custom.zeroArgBuiltin": () => `hello`,
+      "custom.oneArgBuiltin": (arg0) => `hello ${arg0}`,
+      "custom.twoArgBuiltin": (arg0, arg1) => `hello ${arg0}, ${arg1}`,
+      "custom.threeArgBuiltin": (arg0, arg1, arg2) => (
+        `hello ${arg0}, ${arg1}, ${arg2}`
+      ),
+      "custom.fourArgBuiltin": (arg0, arg1, arg2, arg3) => (
+        `hello ${arg0}, ${arg1}, ${arg2}, ${arg3}`
+      ),
+      "json.is_valid": () => {
+        throw new Error("should never happen");
+      },
+    });
+  });
+
+  it("should call a custom zero-arg builtin", () => {
+    const result = policy.evaluate({}, "custom_builtins/zero_arg");
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({ result: "hello" });
+  });
+
+  it("should call a custom one-arg builtin", () => {
+    const result = policy.evaluate(
+      { args: ["arg0"] },
+      "custom_builtins/one_arg",
+    );
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({ result: "hello arg0" });
+  });
+
+  it("should call a custom two-arg builtin", () => {
+    const result = policy.evaluate(
+      { args: ["arg0", "arg1"] },
+      "custom_builtins/two_arg",
+    );
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({
+      result: "hello arg0, arg1",
+    });
+  });
+
+  it("should call a custom three-arg builtin", () => {
+    const result = policy.evaluate(
+      { args: ["arg0", "arg1", "arg2"] },
+      "custom_builtins/three_arg",
+    );
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({
+      result: "hello arg0, arg1, arg2",
+    });
+  });
+
+  it("should call a custom four-arg builtin", () => {
+    const result = policy.evaluate(
+      { args: ["arg0", "arg1", "arg2", "arg3"] },
+      "custom_builtins/four_arg",
+    );
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({
+      result: "hello arg0, arg1, arg2, arg3",
+    });
+  });
+
+  it("should call a provided builtin over a custom builtin", () => {
+    const result = policy.evaluate({}, "custom_builtins/valid_json");
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({ result: true });
+  });
+});


### PR DESCRIPTION
Hi,

This PR adds support for custom builtins by adding an additional parameter to loadPolicy, somewhat related to the discussion in #23.

One potential point of contention is that this always favors first-party builtins over provided builtins.

P.S. opa is fantastic - great work!