### PR TITLE
Signed-off-by: Mauricio Caro <maucaro@outlook.com>

### DIFF
--- a/examples/nodejs-ts-app/README.md
+++ b/examples/nodejs-ts-app/README.md
@@ -23,9 +23,9 @@ npm run build
 ## Run the example Node JS code that invokes the Wasm binary:
 
 ```bash
-npm run -- '{\"message\": \"world\"}'
+npm start -- '{\"message\": \"world\"}'
 ```
 
 ```bash
-npm run -- '{\"message\": \"not-world\"}'
+npm start -- '{\"message\": \"not-world\"}'
 ```

--- a/examples/nodejs-ts-app/package.json
+++ b/examples/nodejs-ts-app/package.json
@@ -4,7 +4,7 @@
   "description": "demo app",
   "main": "app.js",
   "scripts": {
-    "build": "opa build -t wasm -e 'example/hello' ./example.rego && tar xzf ./bundle.tar.gz /policy.wasm",
+    "build": "opa build -t wasm -e example/hello ./example.rego && tar xzf ./bundle.tar.gz /policy.wasm",
     "start": "ts-node app.ts"
   },
   "dependencies": {


### PR DESCRIPTION
Removed unnecessary quotes from npm build command, which are problematic in Windows with PowerShell, and corrected README: from "npm start..." to "npm run..."