### PR TITLE
examples: remove single quotes around entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ or `opa build` CLI tool.
 For example, with OPA v0.20.5+:
 
 ```bash
-opa build -t wasm -e 'example/allow' example.rego
+opa build -t wasm -e example/allow example.rego
 ```
 
 Which is compiling the `example.rego` policy file with the result set to

--- a/examples/nodejs-app/README.md
+++ b/examples/nodejs-app/README.md
@@ -23,7 +23,7 @@ There is an example policy included with the example, see
 [example.rego](./example.rego)
 
 ```bash
-opa build -t wasm -e 'example/hello' ./example.rego
+opa build -t wasm -e example/hello ./example.rego
 tar -xzf ./bundle.tar.gz /policy.wasm
 ```
 

--- a/examples/nodejs-ts-app-multi-entrypoint/package.json
+++ b/examples/nodejs-ts-app-multi-entrypoint/package.json
@@ -4,7 +4,7 @@
   "description": "demo app for a multi entrypoint WASM build",
   "main": "app.ts",
   "scripts": {
-    "build": "opa build -t wasm -e 'example' -e 'example/one' -e 'example/two' -e 'example/two/coolRule' ./policies && tar -xzf ./bundle.tar.gz /policy.wasm",
+    "build": "opa build -t wasm -e example -e example/one -e example/two -e example/two/coolRule ./policies && tar -xzf ./bundle.tar.gz /policy.wasm",
     "start": "ts-node app.ts"
   },
   "dependencies": {


### PR DESCRIPTION
These, too, are unnecessary and cause trouble on powershell.
