### PR TITLE
ci: use node 12, 14, 16, 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x, 18.x]
         opa-version:
         - 0.30.2 # last version with ABI 1.1, 0.31.0+ has ABI 1.2
         - 0.39.0 # 0.35.0 is the first release with https://github.com/open-policy-agent/opa/pull/4055


### PR DESCRIPTION
Node 10 has been EOL for a while, and node 18 was released recently.