### PR TITLE
Signed-off-by: Mauricio Caro <maucaro@outlook.com> Simplifying exports to enable broader usage

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,8 @@ $(npm bin)/esbuild $entrypoint \
   --format=iife \
   --platform=browser \
   --define:global=window \
-  --global-name=opa
+  --global-name=opa \
+  --external:util
 
 echo "Generating esm browser build…"
 $(npm bin)/esbuild $entrypoint \
@@ -31,7 +32,8 @@ $(npm bin)/esbuild $entrypoint \
   --minify \
   --format=esm \
   --platform=browser \
-  --define:global=window
+  --define:global=window \
+  --external:util
 
 echo "Generating TypeScript declaration file…"
 $(npm bin)/tsc ./src/index.mjs \

--- a/package.json
+++ b/package.json
@@ -5,19 +5,8 @@
   "main": "./src/index.cjs",
   "types": "./dist/types/opa.d.ts",
   "exports": {
-    "node": {
-      "import": "./src/index.mjs",
-      "require": "./src/index.cjs"
-    },
-    "browser": {
-      "import": "./dist/opa-wasm-browser.esm.js",
-      "require": "./src/index.cjs",
-      "default": "./dist/opa-wasm-browser.js"
-    }
-  },
-  "browser": {
-    "//": "This ensures that the util module isn't bundled in browsers",
-    "util": false
+    "import": "./src/index.mjs",
+    "require": "./src/index.cjs"
   },
   "files": [
     "capabilities.json",

--- a/src/opa.js
+++ b/src/opa.js
@@ -2,16 +2,6 @@
 // Use of this source code is governed by an Apache2
 // license that can be found in the LICENSE file.
 const builtIns = require("./builtins/index");
-const util = require("util");
-
-// NOTE: The util shim here exists for Node 10.x and can be removed
-// when dropping support. Browsers and Node >= 11.x use the global.
-const TextEncoder = typeof global.TextEncoder !== "undefined"
-  ? global.TextEncoder
-  : util.TextEncoder;
-const TextDecoder = typeof global.TextDecoder !== "undefined"
-  ? global.TextDecoder
-  : util.TextDecoder;
 
 /**
  * @param {WebAssembly.Memory} mem


### PR DESCRIPTION
As discussed, these changes allow for easier consumption from environments other than Node (Angular for example) by exposing both CommonJS and ES module imports as described in [Conditional Exports](https://nodejs.org/api/packages.html#conditional-exports).