### PR TITLE
Package support seems not to work

### DIFF
--- a/test/fixtures/package/.gitignore
+++ b/test/fixtures/package/.gitignore
@@ -1,0 +1,2 @@
+bundle.tar.gz
+policy.wasm

--- a/test/fixtures/package/namespace.rego
+++ b/test/fixtures/package/namespace.rego
@@ -1,0 +1,7 @@
+package a.b.c
+
+default allow = false
+
+allow {
+    input.alpha == input.beta
+}

--- a/test/opa-package.test.js
+++ b/test/opa-package.test.js
@@ -1,0 +1,54 @@
+const { readFileSync } = require("fs");
+const { execFileSync } = require("child_process");
+const { loadPolicy } = require("../src/opa.js");
+const util = require("util");
+
+describe("package support", () => {
+  const fixturesFolder = "test/fixtures/package";
+
+  const packageName = "a.b.c"
+
+  let policy;
+
+  beforeAll(async () => {
+    const bundlePath = `${fixturesFolder}/bundle.tar.gz`;
+
+    execFileSync("opa", [
+      "build",
+      fixturesFolder,
+      "-o",
+      bundlePath,
+      "-t",
+      "wasm",
+      "-e",
+      `${packageName}/allow`,
+    ]);
+
+    execFileSync("tar", [
+      "-xzf",
+      bundlePath,
+      "-C",
+      `${fixturesFolder}/`,
+      "/policy.wasm",
+    ]);
+
+    const policyWasm = readFileSync(`${fixturesFolder}/policy.wasm`);
+    const opts = { initial: 5, maximum: 10 };
+    policy = await loadPolicy(policyWasm, opts);
+  });
+
+
+  it("should handle packaged data", () => {
+    policy.setData({});
+
+    //  positive check
+    let result = policy.evaluate({ "alpha": "yoyo", "beta": "yoyo"});
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({ result: true });
+
+    //  negative check
+    result = policy.evaluate({ "alpha": "yoyo", "beta": "theremin"});
+    expect(result.length).not.toBe(0);
+    expect(result[0]).toMatchObject({ result: false });
+  });
+});


### PR DESCRIPTION
I'm not sure if I misunderstand using packages, but when I use packages in the rego I am not able to get a proper response using npm-opa-wasm. 

I am able to run an `opa run -s` approach to do the queries which works - but not using policy.wasm from the bundle.

I raised this as a PR to demonstrate the problematic behaviour (i.e. not suggesting you should merge this!).

## Making it pass

Changing the rego to use a simple package - e.g. `a`, and updating the `const packageName` in the test case makes things work how I would expect.


