### PR TITLE
feat: add loadPolicySync

### DIFF
--- a/test/browser-integration.test.js
+++ b/test/browser-integration.test.js
@@ -64,6 +64,22 @@ test("default script should expose working opa global", async () => {
   ]);
 });
 
+test("loadPolicySync can be used inside a worker thread", async () => {
+  const result = await page.evaluate(function () {
+    return new Promise((resolve, _) => {
+      const worker = new Worker("/test/fixtures/load-policy-sync-worker.js");
+      worker.onmessage = function (e) {
+        resolve(e.data);
+      };
+    });
+  });
+  expect(result).toEqual([
+    {
+      result: { myOtherRule: false, myRule: false },
+    },
+  ]);
+});
+
 async function startStaticServer() {
   // Basic webserver to serve the test suite relative to the root.
   const server = http.createServer(function (req, res) {

--- a/test/fixtures/load-policy-sync-worker.js
+++ b/test/fixtures/load-policy-sync-worker.js
@@ -1,0 +1,10 @@
+(async () => {
+  importScripts("/dist/opa-wasm-browser.js");
+
+  const wasm = await fetch("/test/fixtures/multiple-entrypoints/policy.wasm")
+    .then((r) => r.blob())
+    .then((b) => b.arrayBuffer());
+
+  const policy = opa.loadPolicySync(wasm);
+  this.postMessage(policy.evaluate({}, "example/one"));
+})();

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -1,7 +1,7 @@
 const { readFileSync } = require("fs");
 const { execFileSync } = require("child_process");
 const semver = require("semver");
-const { loadPolicy } = require("../src/opa.js");
+const { loadPolicy, loadPolicySync } = require("../src/opa.js");
 
 describe("growing memory", () => {
   const fixturesFolder = "test/fixtures/memory";
@@ -71,5 +71,11 @@ describe("growing memory", () => {
     for (const _ of new Array(16)) {
       expect(() => policy.evaluate(input)).not.toThrow();
     }
+  });
+
+  it("large input, host and guest grow successfully (synchronous load)", () => {
+    const policy = loadPolicySync(policyWasm, { initial: 2, maximum: 8 });
+    const input = "a".repeat(2 * 65536);
+    expect(() => policy.evaluate(input)).not.toThrow();
   });
 });


### PR DESCRIPTION
See #251 

Replacing loadPolicy with loadPolicySync in opa-test-cases.test.js gives the same number of pass/fails (and a little quicker?) but not sure you want to be testing both every time.

Added a browser test in a worker (loadPolicySync can't be used in main browser thread) and another small test.

Happy to hear any improvements or suggestions for tests.