### PR TITLE
ci: fix node-18 build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ if [[ ! -x $(npm bin)/esbuild || ! -x $(npm bin)/tsc ]]; then
 fi
 
 echo "Generating default browser build…"
-$(npm bin)/esbuild $entrypoint \
+npx esbuild $entrypoint \
   --outfile=$outdir/$package-browser.js \
   --bundle \
   --sourcemap \
@@ -25,7 +25,7 @@ $(npm bin)/esbuild $entrypoint \
   --external:util
 
 echo "Generating esm browser build…"
-$(npm bin)/esbuild $entrypoint \
+npx esbuild $entrypoint \
   --outfile=$outdir/$package-browser.esm.js \
   --bundle \
   --sourcemap \
@@ -36,7 +36,7 @@ $(npm bin)/esbuild $entrypoint \
   --external:util
 
 echo "Generating TypeScript declaration file…"
-$(npm bin)/tsc ./src/index.mjs \
+npx tsc ./src/index.mjs \
   --declaration \
   --allowJs \
   --emitDeclarationOnly \


### PR DESCRIPTION
Fixing the CI build for Node 18

- Ci constantly fails with `Command not found`, `npm bin` is most likely not getting the right path. Using `npx` to fix this
