### PR TITLE
Fix importing types on Node 16 module resolution

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,3 +41,6 @@ npx tsc ./src/index.mjs \
   --allowJs \
   --emitDeclarationOnly \
   --outDir $outdir/types
+
+mv $outdir/types/opa.d.ts $outdir/types/opa.d.mts
+cp $outdir/types/opa.d.mts $outdir/types/opa.d.cts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1432,6 +1432,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/@puppeteer/browsers/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -3759,6 +3774,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -4853,6 +4880,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/yaml": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
@@ -5884,6 +5917,17 @@
         "tar-fs": "3.0.5",
         "unbzip2-stream": "1.4.3",
         "yargs": "17.7.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@sinclair/typebox": {
@@ -7634,6 +7678,15 @@
         "p-locate": "^4.1.0"
       }
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -8437,6 +8490,12 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yaml": {

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "1.8.1",
   "description": "Open Policy Agent WebAssembly SDK",
   "main": "./src/index.cjs",
-  "types": "./dist/types/opa.d.ts",
+  "types": "./dist/types/opa.d.cts",
   "exports": {
     ".": {
       "types": {
-        "import": "./dist/types/opa.d.ts",
-        "require": "./dist/types/opa.d.ts"
+        "import": "./dist/types/opa.d.mts",
+        "require": "./dist/types/opa.d.cts"
       },
       "import": "./src/index.mjs",
       "require": "./src/index.cjs"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,14 @@
   "main": "./src/index.cjs",
   "types": "./dist/types/opa.d.ts",
   "exports": {
-    "import": "./src/index.mjs",
-    "require": "./src/index.cjs"
+    ".": {
+      "types": {
+        "import": "./dist/types/opa.d.ts",
+        "require": "./dist/types/opa.d.ts"
+      },
+      "import": "./src/index.mjs",
+      "require": "./src/index.cjs"
+    }
   },
   "files": [
     "capabilities.json",


### PR DESCRIPTION
Fixes https://github.com/open-policy-agent/npm-opa-wasm/issues/332

I upgraded my TypeScript moduleResolution to Node 16, and TypeScript stopped being able to find the types. This change should fix it.