### PR TITLE
Support webassembly instantiate streaming

### DIFF
--- a/src/opa.js
+++ b/src/opa.js
@@ -262,7 +262,7 @@ function _preparePolicy(env, wasm, memory) {
  * It will return a Promise, depending on the input type the promise
  * resolves to both a compiled WebAssembly.Module and its first WebAssembly.Instance
  * or to the WebAssemblyInstance.
- * @param {BufferSource | WebAssembly.Module | Response | PromiseLike<Response>} policyWasm
+ * @param {BufferSource | WebAssembly.Module | Response | Promise<Response>} policyWasm
  * @param {WebAssembly.Memory} memory
  * @param {{ [builtinName: string]: Function }} customBuiltins
  * @returns {Promise<{ policy: WebAssembly.WebAssemblyInstantiatedSource | WebAssembly.Instance, minorVersion: number }>}
@@ -270,12 +270,7 @@ function _preparePolicy(env, wasm, memory) {
 async function _loadPolicy(policyWasm, memory, customBuiltins) {
   const env = {};
 
-  const isStreaming =
-  policyWasm instanceof Response ||
-  policyWasm instanceof Promise ||
-  (typeof policyWasm === "object" &&
-    "then" in policyWasm &&
-    typeof policyWasm === "function");
+  const isStreaming = policyWasm instanceof Response || policyWasm instanceof Promise;
 
   const importObject = _importObject(env, memory, customBuiltins);
 
@@ -468,7 +463,7 @@ module.exports = {
    * To set custom memory size specify number of memory pages
    * as second param.
    * Defaults to 5 pages (320KB).
-   * @param {BufferSource | WebAssembly.Module | Response | PromiseLike<Response>} regoWasm
+   * @param {BufferSource | WebAssembly.Module | Response | Promise<Response>} regoWasm
    * @param {number | WebAssembly.MemoryDescriptor} memoryDescriptor For backwards-compatibility, a 'number' argument is taken to be the initial memory size.
    * @param {{ [builtinName: string]: Function }} customBuiltins A map from string names to builtin functions
    * @returns {Promise<LoadedPolicy>}

--- a/src/opa.js
+++ b/src/opa.js
@@ -262,7 +262,7 @@ function _preparePolicy(env, wasm, memory) {
  * It will return a Promise, depending on the input type the promise
  * resolves to both a compiled WebAssembly.Module and its first WebAssembly.Instance
  * or to the WebAssemblyInstance.
- * @param {BufferSource | WebAssembly.Module} policyWasm
+ * @param {BufferSource | WebAssembly.Module | Response | PromiseLike<Response>} policyWasm
  * @param {WebAssembly.Memory} memory
  * @param {{ [builtinName: string]: Function }} customBuiltins
  * @returns {Promise<{ policy: WebAssembly.WebAssemblyInstantiatedSource | WebAssembly.Instance, minorVersion: number }>}
@@ -270,10 +270,18 @@ function _preparePolicy(env, wasm, memory) {
 async function _loadPolicy(policyWasm, memory, customBuiltins) {
   const env = {};
 
-  const wasm = await WebAssembly.instantiate(
-    policyWasm,
-    _importObject(env, memory, customBuiltins),
-  );
+  const isStreaming =
+  policyWasm instanceof Response ||
+  policyWasm instanceof Promise ||
+  (typeof policyWasm === "object" &&
+    "then" in policyWasm &&
+    typeof policyWasm === "function");
+
+  const importObject = _importObject(env, memory, customBuiltins);
+
+  const wasm = await (isStreaming
+    ? WebAssembly.instantiateStreaming(policyWasm, importObject)
+    : WebAssembly.instantiate(policyWasm, importObject));
 
   return _preparePolicy(env, wasm, memory);
 }
@@ -460,7 +468,7 @@ module.exports = {
    * To set custom memory size specify number of memory pages
    * as second param.
    * Defaults to 5 pages (320KB).
-   * @param {BufferSource | WebAssembly.Module} regoWasm
+   * @param {BufferSource | WebAssembly.Module | Response | PromiseLike<Response>} regoWasm
    * @param {number | WebAssembly.MemoryDescriptor} memoryDescriptor For backwards-compatibility, a 'number' argument is taken to be the initial memory size.
    * @param {{ [builtinName: string]: Function }} customBuiltins A map from string names to builtin functions
    * @returns {Promise<LoadedPolicy>}

--- a/src/opa.js
+++ b/src/opa.js
@@ -270,13 +270,15 @@ function _preparePolicy(env, wasm, memory) {
 async function _loadPolicy(policyWasm, memory, customBuiltins) {
   const env = {};
 
-  const isStreaming = policyWasm instanceof Response || policyWasm instanceof Promise;
+  const isStreaming = policyWasm instanceof Response ||
+    policyWasm instanceof Promise;
 
   const importObject = _importObject(env, memory, customBuiltins);
 
-  const wasm = await (isStreaming
-    ? WebAssembly.instantiateStreaming(policyWasm, importObject)
-    : WebAssembly.instantiate(policyWasm, importObject));
+  const wasm =
+    await (isStreaming
+      ? WebAssembly.instantiateStreaming(policyWasm, importObject)
+      : WebAssembly.instantiate(policyWasm, importObject));
 
   return _preparePolicy(env, wasm, memory);
 }

--- a/test/browser-integration.test.js
+++ b/test/browser-integration.test.js
@@ -41,6 +41,20 @@ test("esm script should expose working opa module", async () => {
   ]);
 });
 
+test("loadPolicy should allow for a response object that resolves to a fetched wasm module", async () => {
+  const result = await page.evaluate(async function () {
+    // NOTE: Paths are evaluated relative to the project root.
+    const { default: opa } = await import("/dist/opa-wasm-browser.esm.js");
+    const policy = await opa.loadPolicy(fetch("/test/fixtures/multiple-entrypoints/policy.wasm"));
+    return policy.evaluate({}, "example/one");
+  });
+  expect(result).toEqual([
+    {
+      result: { myOtherRule: false, myRule: false },
+    },
+  ]);
+});
+
 test("default script should expose working opa global", async () => {
   // Load module into global scope.
   const script = fs.readFileSync(

--- a/test/browser-integration.test.js
+++ b/test/browser-integration.test.js
@@ -45,7 +45,9 @@ test("loadPolicy should allow for a response object that resolves to a fetched w
   const result = await page.evaluate(async function () {
     // NOTE: Paths are evaluated relative to the project root.
     const { default: opa } = await import("/dist/opa-wasm-browser.esm.js");
-    const policy = await opa.loadPolicy(fetch("/test/fixtures/multiple-entrypoints/policy.wasm"));
+    const policy = await opa.loadPolicy(
+      fetch("/test/fixtures/multiple-entrypoints/policy.wasm"),
+    );
     return policy.evaluate({}, "example/one");
   });
   expect(result).toEqual([


### PR DESCRIPTION
This allows passing a `Response` or `Promise<Response>` to `loadPolicy` which will pass the response to [`WebAssembly.instantiateStreaming()`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/instantiateStreaming_static) instead of [`WebAssembly.instantiate()`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/instantiate_static) to allow fulfilling the [suggestion from MDN](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/instantiate_static#:~:text=Warning%3A%20This%20method%20is%20not%20the%20most%20efficient%20way%20of%20fetching%20and%20instantiating%20Wasm)