### PR TITLE
Release 1.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-policy-agent/opa-wasm",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-policy-agent/opa-wasm",
-      "version": "1.8.1",
+      "version": "1.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "sprintf-js": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-policy-agent/opa-wasm",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Open Policy Agent WebAssembly SDK",
   "main": "./src/index.cjs",
   "types": "./dist/types/opa.d.ts",


### PR DESCRIPTION
This release brings support for  WebAssembly.initiateStreaming:

Passing a Response or Promise<Response> to loadPolicy will pass the response to WebAssembly.instantiateStreaming() instead of WebAssembly.instantiate() to allow fulfilling the suggestion from MDN.

Thanks to @Tucker-Eric!