### PR TITLE
fix: modernize CI for OPA v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 21.x]
+        node-version: [22.x, 24.x, 26.x]
         opa-version:
-        - 0.30.2 # last version with ABI 1.1, 0.31.0+ has ABI 1.2
-        - 0.41.0 # 0.35.0 is the first release with https://github.com/open-policy-agent/opa/pull/4055
+        - 1.18.2
 
     steps:
     - uses: actions/checkout@v4
@@ -54,8 +53,7 @@ jobs:
     - name: Unpack OPA cases
       run: >
         tar zxvf opa/.go/cache/testcases.tar.gz --exclude='*.js' -C test/cases &&
-        mv opa/test/cases/testdata testdata &&
-        rm -rf opa/
+        mv opa/v1/test/cases/testdata testdata
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
@@ -66,12 +64,16 @@ jobs:
       uses: open-policy-agent/setup-opa@v2
       with:
         version: v${{ matrix.opa-version }}
+    - name: Install Chrome
+      id: setup-chrome
+      uses: browser-actions/setup-chrome@v1
     - run: npm ci
     - run: npm run build
     - run: npm test
       env:
         OPA_CASES: test/cases/
         OPA_TEST_CASES: testdata
+        PUPPETEER_EXECUTABLE_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
 
   examples-node:
     name: NodeJS examples
@@ -83,7 +85,7 @@ jobs:
       with:
         node-version: "20.x"
     - name: nodejs
-      run: >
+      run: |
         npm ci
         npm run build
         ./e2e.sh

--- a/examples/deno/test.rego
+++ b/examples/deno/test.rego
@@ -1,5 +1,5 @@
 package test
 
-p {
+p if {
     input.foo == "bar"
 }

--- a/examples/nodejs-ts-app/example.rego
+++ b/examples/nodejs-ts-app/example.rego
@@ -1,8 +1,8 @@
 package example
 
-default hello = false
+default hello := false
 
-hello {
+hello if {
     x := input.message
     x == data.world
 }

--- a/examples/nodejs-ts-app/package-lock.json
+++ b/examples/nodejs-ts-app/package-lock.json
@@ -18,20 +18,21 @@
     },
     "../..": {
       "name": "@open-policy-agent/opa-wasm",
-      "version": "1.6.0",
+      "version": "1.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "sprintf-js": "^1.1.2",
         "yaml": "^1.10.2"
       },
       "devDependencies": {
-        "esbuild": "^0.14.5",
-        "jest": "^27.2.4",
-        "puppeteer": "^13.0.0",
+        "@types/node": "^22.9.0",
+        "esbuild": "^0.24.0",
+        "jest": "^29.0.0",
+        "puppeteer": "^23.4.0",
         "semver": "^7.3.5",
         "smart-deep-sort": "^1.0.2",
         "tmp": "^0.2.1",
-        "typescript": "^4.4.3"
+        "typescript": "^5.3.3"
       }
     },
     "../../node_modules/@babel/code-frame": {
@@ -5875,6 +5876,21 @@
         "typescript": ">=2.7"
       }
     },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://npm.flatt.tech/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -5889,14 +5905,15 @@
     "@open-policy-agent/opa-wasm": {
       "version": "file:../..",
       "requires": {
-        "esbuild": "^0.14.5",
-        "jest": "^27.2.4",
-        "puppeteer": "^13.0.0",
+        "@types/node": "^22.9.0",
+        "esbuild": "^0.24.0",
+        "jest": "^29.0.0",
+        "puppeteer": "^23.4.0",
         "semver": "^7.3.5",
         "smart-deep-sort": "^1.0.2",
         "sprintf-js": "^1.1.2",
         "tmp": "^0.2.1",
-        "typescript": "^4.4.3",
+        "typescript": "^5.3.3",
         "yaml": "^1.10.2"
       },
       "dependencies": {
@@ -10599,6 +10616,13 @@
         "source-map-support": "^0.5.17",
         "yn": "3.1.1"
       }
+    },
+    "typescript": {
+      "version": "6.0.3",
+      "resolved": "https://npm.flatt.tech/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "peer": true
     },
     "yn": {
       "version": "3.1.1",

--- a/examples/nodejs-ts-app/tsconfig.json
+++ b/examples/nodejs-ts-app/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "node",
     "noEmit": true,
     "strict": true,
+    "types": ["node"],
     "baseUrl": "./",
     "paths": {
       "@open-policy-agent/opa-wasm": ["../../"]

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "fmt": "git ls-files | xargs deno fmt",
     "test": "jest --verbose"
   },
+  "jest": {
+    "testPathIgnorePatterns": ["/node_modules/", "/opa/"]
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/open-policy-agent/npm-opa-wasm.git"

--- a/test/browser-integration.test.js
+++ b/test/browser-integration.test.js
@@ -14,14 +14,21 @@ beforeAll(async () => {
   server = await startStaticServer();
   const port = server.address().port;
 
-  browser = await puppeteer.launch();
+  browser = await puppeteer.launch({
+    args: ["--no-sandbox"],
+    executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
+  });
   page = await browser.newPage();
   await page.goto(`http://localhost:${port}/`);
 });
 
 afterAll(async () => {
-  await browser.close();
-  server.close();
+  if (browser) {
+    await browser.close();
+  }
+  if (server) {
+    server.close();
+  }
 });
 
 test("esm script should expose working opa module", async () => {

--- a/test/fixtures/custom-builtins/capabilities.json
+++ b/test/fixtures/custom-builtins/capabilities.json
@@ -1,4 +1,5 @@
 {
+  "features": ["rego_v1"],
   "builtins": [
     {
       "name": "custom.zeroArgBuiltin",

--- a/test/fixtures/custom-builtins/custom-builtins-policy.rego
+++ b/test/fixtures/custom-builtins/custom-builtins-policy.rego
@@ -1,25 +1,25 @@
 package custom_builtins
 
-zero_arg = x {
+zero_arg = x if {
   x = custom.zeroArgBuiltin()
 }
 
-one_arg = x {
+one_arg = x if {
     x = custom.oneArgBuiltin(input.args[0])
 }
 
-two_arg = x {
+two_arg = x if {
     x = custom.twoArgBuiltin(input.args[0], input.args[1])
 }
 
-three_arg = x {
+three_arg = x if {
     x = custom.threeArgBuiltin(input.args[0], input.args[1], input.args[2])
 }
 
-four_arg = x {
+four_arg = x if {
     x = custom.fourArgBuiltin(input.args[0], input.args[1], input.args[2], input.args[3])
 }
 
-valid_json {
+valid_json if {
     json.is_valid("{}")
 }

--- a/test/fixtures/data-stress/example-one.rego
+++ b/test/fixtures/data-stress/example-one.rego
@@ -1,17 +1,17 @@
 package example.one
 
-default myRule = false
-default myOtherRule = false
+default myRule := false
+default myOtherRule := false
 
-myRule {
+myRule if {
     input.someProp == "thisValue"
 }
 
-myOtherRule {
+myOtherRule if {
     input.anotherProp == "thatValue"
 }
 
-myCompositeRule {
+myCompositeRule if {
     myRule
     myOtherRule
 }

--- a/test/fixtures/memory/policy.rego
+++ b/test/fixtures/memory/policy.rego
@@ -1,5 +1,5 @@
 package test
 
-default allow = false
+default allow := false
 
-allow { input == "open sesame" }
+allow if { input == "open sesame" }

--- a/test/fixtures/multiple-entrypoints/example-one.rego
+++ b/test/fixtures/multiple-entrypoints/example-one.rego
@@ -1,17 +1,17 @@
 package example.one
 
-default myRule = false
-default myOtherRule = false
+default myRule := false
+default myOtherRule := false
 
-myRule {
+myRule if {
     input.someProp == "thisValue"
 }
 
-myOtherRule {
+myOtherRule if {
     input.anotherProp == "thatValue"
 }
 
-myCompositeRule {
+myCompositeRule if {
     myRule
     myOtherRule
 }

--- a/test/fixtures/multiple-entrypoints/example-two.rego
+++ b/test/fixtures/multiple-entrypoints/example-two.rego
@@ -1,17 +1,17 @@
 package example.two
 
-default theirRule = false
-default ourRule = false
+default theirRule := false
+default ourRule := false
 
-theirRule {
+theirRule if {
     input.anyProp == "aValue"
 }
 
-ourRule {
+ourRule if {
     input.ourProp == "inTheMiddleOfTheStreet"
 }
 
-coolRule {
+coolRule if {
     theirRule
     ourRule
 }

--- a/test/fixtures/stringified-support/stringified-support-policy.rego
+++ b/test/fixtures/stringified-support/stringified-support-policy.rego
@@ -1,26 +1,26 @@
 package stringified.support
 
-default hasPermission = false
-default plainInputBoolean = false
-default plainInputNumber = false
-default plainInputString = false
+default hasPermission := false
+default plainInputBoolean := false
+default plainInputNumber := false
+default plainInputString := false
 
-hasPermission {
+hasPermission if {
     input.secret == data.secret
 }
 
-hasPermission {
+hasPermission if {
     input.permissions[_] == data.roles["1"].permissions[_].id
 }
 
-plainInputBoolean {
+plainInputBoolean if {
     input = true
 }
 
-plainInputNumber {
+plainInputNumber if {
     input = 5
 }
 
-plainInputString {
+plainInputString if {
     input = "test"
 }

--- a/test/fixtures/yaml-support/yaml-support-policy.rego
+++ b/test/fixtures/yaml-support/yaml-support-policy.rego
@@ -22,37 +22,37 @@ x-amazon-apigateway-policy:
       Resource: '*'
 `
 
-canParseYAML {
+canParseYAML if {
 	resource := yaml.unmarshal(fixture)
 	resource.info.title == "test"
 }
 
-hasSemanticError {
+hasSemanticError if {
 	# see: https://github.com/eemeli/yaml/blob/395f892ec9a26b9038c8db388b675c3281ab8cd3/tests/doc/errors.js#L22
 	yaml.unmarshal("a:\n\t1\nb:\n\t2\n")
 }
 
-hasSyntaxError {
+hasSyntaxError if {
 	# see: https://github.com/eemeli/yaml/blob/395f892ec9a26b9038c8db388b675c3281ab8cd3/tests/doc/errors.js#L49
 	yaml.unmarshal("{ , }\n---\n{ 123,,, }\n")
 }
 
-hasReferenceError {
+hasReferenceError if {
 	# see: https://github.com/eemeli/yaml/blob/395f892ec9a26b9038c8db388b675c3281ab8cd3/tests/doc/errors.js#L245
 	yaml.unmarshal("{ , }\n---\n{ 123,,, }\n")
 }
 
-hasYAMLWarning {
+hasYAMLWarning if {
 	# see: https://github.com/eemeli/yaml/blob/395f892ec9a26b9038c8db388b675c3281ab8cd3/tests/doc/errors.js#L224
 	yaml.unmarshal("%FOO\n---bar\n")
 }
 
-canMarshalYAML[x] {
+canMarshalYAML contains x if {
 	string := yaml.marshal(input)
 	x := yaml.unmarshal(string)
 }
 
-isValidYAML {
+isValidYAML if {
 	yaml.is_valid(fixture) == true
 	yaml.is_valid("foo: {") == false
 	yaml.is_valid("{\"foo\": \"bar\"}") == true

--- a/test/opa-test-cases.test.js
+++ b/test/opa-test-cases.test.js
@@ -91,7 +91,7 @@ if (path === undefined) {
     test.todo("not found, set OPA_TEST_CASES env var");
   });
 } else {
-  for (const file of walk(path)) {
+  for (const file of walk(path).filter((f) => f.endsWith(".yaml"))) {
     describe(file, () => {
       // the raw yaml often posed problems, have opa give us json
       const res = spawnSync("opa", [


### PR DESCRIPTION
Update Rego fixtures and examples for OPA v1 syntax, adjust CI test case paths, and make browser integration tests use an explicit Chrome executable in CI.

